### PR TITLE
hip: move run cache from per function to global

### DIFF
--- a/src/runtime_src/hip/core/common.h
+++ b/src/runtime_src/hip/core/common.h
@@ -11,8 +11,15 @@
 #include "context.h"
 #include "device.h"
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
 #include <stack>
 #include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace xrt::core::hip {
 struct ctx_info
@@ -42,6 +49,109 @@ insert_in_map(map& m, value&& v)
   m.add(handle, std::move(v));
   return handle;
 }
+
+template <typename K, typename T>
+class hip_container {
+private:
+  uint32_t m_max{0};
+  std::unordered_map<const K*, std::vector<T>> m_map;
+  std::mutex m_mutex; // lock to the map
+  uint32_t m_size{0};
+  std::condition_variable m_cv;
+  uint32_t m_nocache{0}; // flag to indicate if caching is stopped
+public:
+  hip_container(uint32_t max): m_max(max) {};
+  hip_container(const hip_container&) = delete;
+  hip_container& operator=(const hip_container&) = delete;
+  hip_container&& operator=(const hip_container&&) = delete;
+  ~hip_container() = default;
+
+  void
+  push(const K* k, T&& t)
+  {
+    std::scoped_lock<std::mutex> lock(m_mutex);
+
+    if (m_size >= m_max || m_nocache != 0)
+      return;
+
+    auto it = m_map.find(k);
+    if (it == m_map.end()) {
+      std::vector<T> temp_vec;
+      temp_vec.push_back(std::move(t));
+      m_map.emplace(k, std::move(temp_vec));
+    }
+    else {
+      auto& temp_vec = it->second;
+      temp_vec.push_back(std::move(t));
+    }
+    m_size++;
+  }
+
+  std::optional<T>
+  get(const K* k)
+  {
+    std::scoped_lock<std::mutex> lock(m_mutex);
+    auto it = m_map.find(k);
+    if (it != m_map.end()) {
+      if (!it->second.empty()) {
+	T t = std::move(it->second.back());
+	it->second.pop_back();
+	m_size--;
+	return t;
+      }
+    }
+    return std::nullopt;
+  }
+
+  void
+  remove(const K* k)
+  {
+    std::scoped_lock<std::mutex> lock(m_mutex);
+    auto it = m_map.find(k);
+    if (it != m_map.end()) {
+      if (it->second.size()) {
+        m_size -= it->second.size();
+        it->second.clear();
+      }
+      m_map.erase(it);
+    }
+  }
+
+  void
+  stop_caching()
+  {
+    std::scoped_lock<std::mutex> lock(m_mutex);
+    if (!m_nocache && m_size) {
+      m_map.clear();
+      m_size = 0;
+    }
+    m_nocache++;
+  }
+
+  void
+  resume_caching()
+
+  {
+    std::scoped_lock<std::mutex> lock(m_mutex);
+    if (m_nocache <= 0) {
+      throw xrt_core::system_error(hipErrorInvalidValue,
+				   "hip_container caching is not stopped");
+    }
+    m_nocache--;
+  }
+
+  static
+  std::shared_ptr<hip_container<K, T>>
+  get_instance(uint32_t max)
+  {
+    static std::shared_ptr<hip_container<K, T>> instance(new hip_container<K, T>(max));
+    if (max != instance->m_max) {
+      throw xrt_core::system_error(hipErrorInvalidValue,
+                                   "hip_container max size cannot be changed after creation");
+    }
+    return instance;
+  }
+};
 } // xrt::core::hip
 
 namespace {

--- a/src/runtime_src/hip/core/module.cpp
+++ b/src/runtime_src/hip/core/module.cpp
@@ -62,6 +62,7 @@ function(module_xclbin* xclbin_mod_hdl, const xrt::module& xrt_module, const std
   : m_xclbin_module{xclbin_mod_hdl}
   , m_func_name{name}
   , m_xrt_kernel{xrt::ext::kernel{m_xclbin_module->get_hw_context(), xrt_module, name}}
+  , m_runs_container{xrt::core::hip::hip_container<function, xrt::run>::get_instance(256)}
 {}
 
 // Global map of modules

--- a/src/runtime_src/hip/core/module.h
+++ b/src/runtime_src/hip/core/module.h
@@ -107,14 +107,19 @@ public:
 class function
 {
   module_xclbin* m_xclbin_module = nullptr;
-  std::vector<xrt::run> m_runs_cache; // cache for the runs to this function
-  std::mutex m_runs_mutex; // lock to m_runs_cache
   std::string m_func_name;
   xrt::kernel m_xrt_kernel;
+  std::shared_ptr<hip_container<function, xrt::run>> m_runs_container;
 
 public:
   function() = default;
   function(module_xclbin* mod_hdl, const xrt::module& xrt_module, const std::string& name);
+  ~function()
+  {
+    if (m_runs_container) {
+      m_runs_container->remove(this);
+    }
+  }
 
   module_xclbin*
   get_module() const
@@ -131,22 +136,33 @@ public:
   xrt::run
   get_run()
   {
-    {
-      std::scoped_lock lock(m_runs_mutex);
-      if (!m_runs_cache.empty()) {
-        auto run = std::move(m_runs_cache.back());
-        m_runs_cache.pop_back();
+    auto opt_run = m_runs_container->get(this);
+    if (opt_run)
+      return opt_run.value();
+
+    try {
+      auto run = xrt::run(m_xrt_kernel);
+      return run;
+    }
+    catch (const xrt_core::system_error& e) {
+      if (e.get() == ENOSPC) {
+        m_runs_container->stop_caching();
+        auto run = xrt::run(m_xrt_kernel);
+        m_runs_container->resume_caching();
         return run;
+      } else {
+        throw; // rethrow other exceptions which are not ENOSPC
       }
     }
-    return xrt::run(m_xrt_kernel);
+    catch (...) {
+      throw; //Catch all other exceptions and rethrow
+    }
   }
 
   void
   release_run(xrt::run&& run)
   {
-    std::scoped_lock lock(m_runs_mutex);
-    m_runs_cache.push_back(std::move(run));
+    m_runs_container->push(this, std::move(run));
   }
 };
 


### PR DESCRIPTION
Move run cache from per function to global. Global maintains the max number of cached runs allowed for each applicaiton as each run holds buffers.

In case some runs take too much resource, e.g. we have limited instruction buffers heap size for current device. If some run takes too much resource, the following run can ran out of resource, in this case, we stop caching the run to allow user to allocate.

<!-- Thanks for sending a pull request! Please fill out below, remove sections that don't apply for your pull request.  -->
#### Problem solved by the commit

#### Bug / issue (if any) fixed, which PR introduced the bug, how it was discovered

#### How problem was solved, alternative solutions (if any) and why they were rejected

#### Risks (if any) associated the changes in the commit

#### What has been tested and how, request additional testing if necessary

#### Documentation impact (if any)
